### PR TITLE
Add independent interest level filters to each status column

### DIFF
--- a/.replit
+++ b/.replit
@@ -38,3 +38,6 @@ author = "agent"
 task = "shell.exec"
 args = "npm run dev"
 waitForPort = 5000
+
+[agent]
+expertMode = true

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { Prospect } from "@shared/schema";
-import { STATUSES } from "@shared/schema";
+import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
 import { ProspectCard } from "@/components/prospect-card";
 import { AddProspectForm } from "@/components/add-prospect-form";
 import { Briefcase, Plus } from "lucide-react";
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
 
 const columnColors: Record<string, string> = {
   Bookmarked: "bg-blue-500",
@@ -26,6 +27,17 @@ const columnColors: Record<string, string> = {
   Withdrawn: "bg-gray-500",
 };
 
+type InterestFilter = "All" | (typeof INTEREST_LEVELS)[number];
+
+const FILTER_OPTIONS: InterestFilter[] = ["All", ...INTEREST_LEVELS];
+
+const interestFilterStyles: Record<InterestFilter, string> = {
+  All: "data-[active=true]:bg-foreground data-[active=true]:text-background",
+  High: "data-[active=true]:bg-red-500 data-[active=true]:text-white",
+  Medium: "data-[active=true]:bg-amber-500 data-[active=true]:text-white",
+  Low: "data-[active=true]:bg-muted-foreground data-[active=true]:text-background",
+};
+
 function KanbanColumn({
   status,
   prospects,
@@ -35,10 +47,19 @@ function KanbanColumn({
   prospects: Prospect[];
   isLoading: boolean;
 }) {
+  const [interestFilter, setInterestFilter] = useState<InterestFilter>("All");
+
+  const filteredProspects =
+    interestFilter === "All"
+      ? prospects
+      : prospects.filter((p) => p.interestLevel === interestFilter);
+
+  const slugStatus = status.replace(/\s+/g, "-").toLowerCase();
+
   return (
     <div
       className="flex flex-col min-w-[260px] max-w-[320px] w-full bg-muted/40 rounded-md"
-      data-testid={`column-${status.replace(/\s+/g, "-").toLowerCase()}`}
+      data-testid={`column-${slugStatus}`}
     >
       <div className="flex items-center gap-2 px-3 py-2.5 border-b border-border/50">
         <div className={`w-2 h-2 rounded-full ${columnColors[status] || "bg-gray-400"}`} />
@@ -46,11 +67,30 @@ function KanbanColumn({
         <Badge
           variant="secondary"
           className="ml-auto text-[10px] px-1.5 py-0 h-5 min-w-[20px] flex items-center justify-center no-default-active-elevate"
-          data-testid={`badge-count-${status.replace(/\s+/g, "-").toLowerCase()}`}
+          data-testid={`badge-count-${slugStatus}`}
         >
-          {prospects.length}
+          {filteredProspects.length}
         </Badge>
       </div>
+
+      <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border/30">
+        {FILTER_OPTIONS.map((option) => (
+          <button
+            key={option}
+            data-active={interestFilter === option}
+            onClick={() => setInterestFilter(option)}
+            className={cn(
+              "flex-1 text-[11px] font-medium rounded px-1 py-0.5 transition-colors",
+              "text-muted-foreground hover:text-foreground hover:bg-muted",
+              interestFilterStyles[option],
+            )}
+            data-testid={`filter-${slugStatus}-${option.toLowerCase()}`}
+          >
+            {option}
+          </button>
+        ))}
+      </div>
+
       <div className="flex-1 overflow-y-auto px-2 py-2">
         <div className="space-y-2">
           {isLoading ? (
@@ -58,12 +98,27 @@ function KanbanColumn({
               <Skeleton className="h-28 rounded-md" />
               <Skeleton className="h-20 rounded-md" />
             </>
-          ) : prospects.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${status.replace(/\s+/g, "-").toLowerCase()}`}>
-              <p className="text-xs text-muted-foreground">No prospects</p>
+          ) : filteredProspects.length === 0 ? (
+            <div
+              className="flex flex-col items-center justify-center py-8 text-center"
+              data-testid={`empty-${slugStatus}`}
+            >
+              <p className="text-xs text-muted-foreground">
+                {prospects.length === 0
+                  ? "No prospects"
+                  : `No ${interestFilter.toLowerCase()} interest`}
+              </p>
+              {prospects.length > 0 && interestFilter !== "All" && (
+                <button
+                  onClick={() => setInterestFilter("All")}
+                  className="mt-1 text-[11px] text-primary hover:underline"
+                >
+                  Show all
+                </button>
+              )}
             </div>
           ) : (
-            prospects.map((prospect) => (
+            filteredProspects.map((prospect) => (
               <ProspectCard key={prospect.id} prospect={prospect} />
             ))
           )}


### PR DESCRIPTION
🎯 Objective

To create a filter for each column of the Job Tracker based on the interest level (low/medium/high/all). With each column having it's own independent filter. The filtering should not call the server, just show/hide job cards.

🛠️ Changes made

I added a new frontend feature to the Job Tracker app so that each status column has its own independent interest level filter.

Feature requirements added: 

Each status column has a filter control at the top of the column.
Filter options are: All, High, Medium, Low.
Each column has it's own independent filter.
Selecting High, Medium, or Low only shows job cards in that specific column with the matching interest level.
Selecting All restores all cards in that specific column.
Filtering happens only in the frontend UI.
The filtering does not call the server, just shows/hides job cards.
Uses the already loaded cards and simply shows/hides or filters them within each column.
Keeps the UI clean and easy to use.

Updated the interface and relevant frontend state management needed to support this behavior, while preserving the current app behavior otherwise.  

👥 Who needs to review this Pull Request?
No one because this was my fork :)